### PR TITLE
Go update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: ["1.18"]
+        go-version: ["1.17"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 4
+      matrix:
+        go-version: ["1.18"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install dependencies
+        run: go get ./serverless
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1.0.0
+        with:
+          version: "2021.1.2"
+          install-go: false
+          cache-key: ${{ matrix.go-version }}
+      - name: Run tests
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
+  - 1.18.x
 
 env:
   - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.18.x
+  - 1.17.x
 
 env:
   - GO111MODULE=on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changes
 
-## 0.3.1 (unreleased)
+## 0.3.2 (unreleased)
 
 - Add `function_arns` attribute reference
 
+## 0.3.1 (2022-06-15)
 
+- upgraded to Go version 1.17 to trigger building arm64 builds
 ## 0.3.0 (2020-10-26)
 
 - Add support for custom environment variables

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/labd/terraform-provider-serverless
 
-go 1.18
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.25.49

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,70 @@
 module github.com/labd/terraform-provider-serverless
 
-go 1.13
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.25.49
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
-	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/mod v0.1.0
+)
+
+require (
+	cloud.google.com/go v0.45.1 // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-cidr v1.0.1 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-getter v1.4.0 // indirect
+	github.com/hashicorp/go-hclog v0.9.2 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-plugin v1.0.1 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-version v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f // indirect
+	github.com/hashicorp/hcl/v2 v2.0.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8 // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/mattn/go-colorable v0.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.5 // indirect
+	github.com/mitchellh/cli v1.0.0 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/posener/complete v1.2.1 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/ulikunitz/xz v0.5.5 // indirect
+	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
+	github.com/zclconf/go-cty v1.1.0 // indirect
+	github.com/zclconf/go-cty-yaml v1.0.1 // indirect
+	go.opencensus.io v0.22.0 // indirect
+	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586 // indirect
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
+	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/api v0.9.0 // indirect
+	google.golang.org/appengine v1.6.1 // indirect
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
+	google.golang.org/grpc v1.23.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,7 +27,6 @@ github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3A
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.49 h1:j5R2Ey+g8qaiy2NJ9iH+KWzDWS4SjXRCjhc22EeQVE4=
 github.com/aws/aws-sdk-go v1.25.49/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.35.9 h1:b1HiUpdkFLJyoOQ7zas36YHzjNHH0ivHx/G5lWBeg+U=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
@@ -102,7 +101,6 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-plugin-sdk v1.4.0 h1:b1LluARpES0Gq78oF4a9of3eS0iXM5JTwlt604vGvBY=
 github.com/hashicorp/terraform-plugin-sdk v1.4.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
-github.com/hashicorp/terraform-plugin-sdk v1.16.0 h1:NrkXMRjHErUPPTHQkZ6JIn6bByiJzGnlJzH1rVdNEuE=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/serverless/aws.go
+++ b/serverless/aws.go
@@ -24,7 +24,7 @@ func loadAWSCredentials(resource getter) (*credentials.Credentials, error) {
 	if result := re.FindStringSubmatch(callerArn); result != nil {
 		role = result[1]
 	} else {
-		return nil, fmt.Errorf("Could not parse role name from callerArn %s", callerArn)
+		return nil, fmt.Errorf("could not parse role name from callerArn %s", callerArn)
 	}
 
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, role)

--- a/serverless/serverless.go
+++ b/serverless/serverless.go
@@ -204,7 +204,7 @@ func updateEnvWithCredentials(s *Serverless, creds *credentials.Credentials) err
 	// serverless uses the correct credentials
 	credValue, err := creds.Get()
 	if err != nil {
-		return fmt.Errorf("Failed retreiving Assume role credentials:\n%w", err)
+		return fmt.Errorf("failed retreiving Assume role credentials:\n%w", err)
 	}
 
 	newEnv := []string{


### PR DESCRIPTION
- upgraded to go version 1.17 (1.18 did not pass the tests)
-  added a test.yml github workflow
- fixed some styling issues that made tests fail